### PR TITLE
replacing flat with reducer to support edge #1

### DIFF
--- a/src/better-bem.js
+++ b/src/better-bem.js
@@ -7,7 +7,10 @@
 import { isString, isPlainObject, isEmptyObject } from 'typechecker';
 
 const generateClassNamesArray = (input = [], useKeyValuePairs = false) => (
-    [input].flat()
+    [input]
+        .reduce((acc, classNames) => {
+            return acc.concat(classNames);
+        }, [])
         .reduce((acc, classNames) => {
             if (isPlainObject(classNames)) {
                 // only use object keys for which value is thruthy


### PR DESCRIPTION
This pull request fixes the #1 issue.

As [Edge doesn't support the array flat method](https://caniuse.com/#feat=array-flat), I've replaced it by another `reduce`, it's basically an alternative as shown on [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat).